### PR TITLE
add more cards per page

### DIFF
--- a/src/lib/scripts/CardsStore.ts
+++ b/src/lib/scripts/CardsStore.ts
@@ -5,7 +5,7 @@ export const cards = writable<{
   current_page: number;
   num_pages: number;
 }>({
-  cards_per_page: 4,
+  cards_per_page: 10,
   current_page: 1,
   num_pages: 1,
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -128,7 +128,9 @@
  and number of stars -->
 <div id="container">
     <div id="banner">
-        This is a reimplementation of the QIIME 2 Library. The old QIIME 2 Library has been deprecated and for the time being may be found <a href="https://old-library.qiime2.org/">here</a>
+        This is a reimplementation of the QIIME 2 Library.
+        Learn how to add your plugin <a href="https://develop.qiime2.org/en/latest/plugins/how-to-guides/distribute-on-library.html">here</a>.
+        The old QIIME 2 Library has been deprecated and for the time being may be found <a href="https://old-library.qiime2.org/">here</a>.
     </div>
     {#await getOverview()}
         ...getting overview


### PR DESCRIPTION
@Oddant1 , I think it would make sense to include more plugins per page. I'd also like plugins from other groups to show up on the first page (they don't right now). 

Also, I feel like we're safe to reference the instructions for adding plugins now - that's in the second commit. 

What do you think? 