### PR TITLE
NEW: present installation of workshop container by default

### DIFF
--- a/npm-scripts/install-distro.myst.md
+++ b/npm-scripts/install-distro.myst.md
@@ -11,7 +11,7 @@ for downloading and installing Miniconda.
 It is important to follow all of the directions provided in the
 [Miniconda instructions](https://www.anaconda.com/docs/getting-started/miniconda/install),
 particularly ensuring that you run `conda init` at the end of the installation process (via installer or manual command),
-to ensure that your Miniconda installation is fully installed and available for the following commands. 
+to ensure that your Miniconda installation is fully installed and available for the following commands.
 On Windows, [set up WSL](https://learn.microsoft.com/en-us/windows/wsl/install) first, then install Miniconda inside WSL.
 
 
@@ -94,7 +94,10 @@ qiime info
 
 ## Using Docker
 
-Steps 1-3 will guide you through installing `docker` and pulling the image for your selected _base distribution_.
+Steps 1-3 will guide you through installing `docker` and pulling the "workshop" image for your selected _base distribution_.
+The "workshop" image contains some conveniences, like a built-in JupyterLab environment with support for viewing `.qzv` files.
+You can find details about how to use these features [here](https://use.qiime2.org/en/stable/how-to-guides/use-the-workshop-container/).
+If you don't want these features and prefer a smaller container, you can replace the `((distro))-workshop` container name in all steps with `((distro))` (i.e., remove `-workshop`).
 
 ### 1. Install docker
 
@@ -105,7 +108,7 @@ See [https://www.docker.com](https://www.docker.com) for instructions for your p
 Run the following command to pull the selected image:
 
 ```bash
-docker pull quay.io/qiime2/((distro)):((epoch))
+docker pull quay.io/qiime2/((distro))-workshop:((epoch))
 ```
 
 ### 3. Test your install
@@ -115,8 +118,8 @@ Finally, to verify things are working, run:
 ```bash
 docker run \
   -v $(pwd):/data \
-  -it quay.io/qiime2/((distro)):((epoch)) \
+  -it quay.io/qiime2/((distro))-workshop:((epoch)) \
   qiime info
 ```
 
-This command mounts your current working directory as a volume to `/data` inside the container, then starts an interactive session (`-i`) with the command `qiime info` using the image `quay.io/qiime2/((distro)):((epoch))` (`-t`).
+This command mounts your current working directory as a volume to `/data` inside the container, then starts an interactive session (`-i`) with the command `qiime info` using the image `quay.io/qiime2/((distro))-workshop:((epoch))` (`-t`).

--- a/npm-scripts/install-distro.myst.md
+++ b/npm-scripts/install-distro.myst.md
@@ -94,8 +94,9 @@ qiime info
 
 ## Using Docker
 
-Steps 1-3 will guide you through installing `docker` and pulling the "workshop" image for your selected _base distribution_.
-The "workshop" image contains some conveniences, like a built-in JupyterLab environment with support for viewing `.qzv` files.
+Steps 1-3 will guide you through installing `docker` and pulling the image for your selected _base distribution_.
+
+((if:epoch>=2026.7))These steps use the "workshop" image, which contains some conveniences, like a built-in JupyterLab environment with support for viewing `.qzv` files.
 You can find details about how to use these features [here](https://use.qiime2.org/en/stable/how-to-guides/use-the-workshop-container/).
 If you don't want these features and prefer a smaller container, you can replace the `((distro))-workshop` container name in all steps with `((distro))` (i.e., remove `-workshop`).
 
@@ -108,7 +109,7 @@ See [https://www.docker.com](https://www.docker.com) for instructions for your p
 Run the following command to pull the selected image:
 
 ```bash
-docker pull quay.io/qiime2/((distro))-workshop:((epoch))
+docker pull quay.io/qiime2/((docker_image)):((epoch))
 ```
 
 ### 3. Test your install
@@ -118,8 +119,8 @@ Finally, to verify things are working, run:
 ```bash
 docker run \
   -v $(pwd):/data \
-  -it quay.io/qiime2/((distro))-workshop:((epoch)) \
+  -it quay.io/qiime2/((docker_image)):((epoch)) \
   qiime info
 ```
 
-This command mounts your current working directory as a volume to `/data` inside the container, then starts an interactive session (`-i`) with the command `qiime info` using the image `quay.io/qiime2/((distro))-workshop:((epoch))` (`-t`).
+This command mounts your current working directory as a volume to `/data` inside the container, then starts an interactive session (`-i`) with the command `qiime info` using the image `quay.io/qiime2/((docker_image)):((epoch))` (`-t`).

--- a/src/routes/quickstart/[distro]/+page.svelte
+++ b/src/routes/quickstart/[distro]/+page.svelte
@@ -11,15 +11,41 @@
         osx?: string;
     };
 
-    function sortEpochs(a: string, b: string) {
+    // The first epoch whose docker images include the "workshop" variant.
+    const WORKSHOP_IMAGE_EPOCH = "2026.7";
+
+    // Marks a block in the install instructions that only applies to some epochs,
+    // e.g. `((if:epoch>=2026.7))`.
+    const EPOCH_CONDITION = /^\(\(if:epoch(>=|<)(\d+\.\d+)\)\)/;
+
+    function compareEpochs(a: string, b: string) {
         const [yearA, monthA] = a.split(".").map((x) => parseInt(x, 10));
         const [yearB, monthB] = b.split(".").map((x) => parseInt(x, 10));
 
         if (yearA !== yearB) {
-            return yearB - yearA;
+            return yearA - yearB;
         }
 
-        return monthB - monthA;
+        return monthA - monthB;
+    }
+
+    function sortEpochs(a: string, b: string) {
+        return compareEpochs(b, a);
+    }
+
+    // The first node carrying a `value`, which is where an epoch condition marker
+    // would be found for a block such as a paragraph.
+    function firstValueNode(node: any): any {
+        if (typeof node.value === "string") {
+            return node;
+        }
+        for (const child of node.children || []) {
+            const found = firstValueNode(child);
+            if (found) {
+                return found;
+            }
+        }
+        return null;
     }
 
     function defaultLegacyInstallUrl(
@@ -112,6 +138,12 @@
         || defaultLegacyInstallUrl(selectedEpoch, distroName, "osx"),
     );
 
+    let dockerImage: string = $derived(
+        compareEpochs(selectedEpoch, WORKSHOP_IMAGE_EPOCH) >= 0
+            ? `${distroName}-workshop`
+            : distroName,
+    );
+
     let installNotice: string | null = $derived.by(() => {
         if (linuxInstallable && macosInstallable) {
             return null;
@@ -149,9 +181,29 @@
         })
 
         visit(ast, (node) => {
+            if (!Array.isArray(node.children)) {
+                return;
+            }
+            node.children = node.children.filter((child: any) => {
+                const marked = firstValueNode(child);
+                const condition = marked && EPOCH_CONDITION.exec(marked.value);
+                if (!condition) {
+                    return true;
+                }
+                const [marker, operator, epoch] = condition;
+                marked.value = marked.value.slice(marker.length);
+                if (operator === '>=') {
+                    return compareEpochs(selectedEpoch, epoch) >= 0;
+                }
+                return compareEpochs(selectedEpoch, epoch) < 0;
+            });
+        })
+
+        visit(ast, (node) => {
             if (node.value) {
                 let value = node.value
                 value = value.replaceAll('((epoch))', selectedEpoch);
+                value = value.replaceAll('((docker_image))', dockerImage);
                 value = value.replaceAll('((distro))', distroName);
                 value = value.replaceAll('((linux_url))', linuxUrl);
                 value = value.replaceAll('((macos_url))', macosUrl);

--- a/src/routes/quickstart/[distro]/+page.svelte
+++ b/src/routes/quickstart/[distro]/+page.svelte
@@ -11,7 +11,8 @@
         osx?: string;
     };
 
-    // The first epoch whose docker images include the "workshop" variant.
+    // The first epoch for which we will recommend installation of the
+    // the "workshop" variant of the Docker containers.
     const WORKSHOP_IMAGE_EPOCH = "2026.7";
 
     // Marks a block in the install instructions that only applies to some epochs,


### PR DESCRIPTION
Addresses #21.

<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
This recommends installation of the workshop container by default, linking to the instructions on how to use JupyterLab and other features. 
The motivation is that these containers have a lot of convenience functionality, so are a better starting point, and users who want the base container can follow the instructions presented here easily enough to get those. 
We discussed this transition from recommending the base installation to recommending the workshop container in the engineering meeting on July 29, 2025 (in the context of #21) and I believe we agreed on this approach at that time. 
(We talked about presenting both sets of instructions, but I don't know that that's needed.)

Thoughts on this? 
Any reason we don't want to recommend the workshop container?  
I'm leaving this as a draft for now b/c I want to review the built pages and I'm not certain how to do that. 
The build didn't include the updates after my first commit - can someone advise on that? 

I reviewed the JS code in the second commit, and it looks sane to me, but I'm not the best person to review so it would help to have another set of eyes on that.  

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [] NO AI USED.
- [X] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
AI not used in preparation of the instructions (the first commit).
AI used for the conditional printing of the instructions. 